### PR TITLE
Add dual license for code and content

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,47 @@
+# Portfolio License
+
+## Code (MIT License)
+
+Copyright (c) 2025 Benjamin P. Haddon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Content (CC BY-NC-ND 4.0)
+
+All textual content, research briefs, site copy, podcast scripts, generated images, and other creative or narrative work in this repository are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License.
+
+### You may
+
+- Share — copy and redistribute the material in any medium or format.
+- Use the content for non-commercial purposes.
+- Provide proper attribution. Please credit: Benjamin P. Haddon (GitHub: benwassa).
+
+### You may not
+
+- Use the material for commercial purposes.
+- Remix, transform, or build upon the material.
+- Remove or alter the attribution.
+
+For the full license text, visit <https://creativecommons.org/licenses/by-nc-nd/4.0/>.
+
+## Summary
+
+- Code (HTML, CSS, JS, and other software scaffolding) is released under the MIT License.
+- Content is available under CC BY-NC-ND 4.0 and requires attribution.
+- Please credit: Benjamin P. Haddon (GitHub: benwassa).


### PR DESCRIPTION
## Summary
- add MIT license coverage for code
- document CC BY-NC-ND 4.0 terms for site content
- clarify attribution requirements and overall licensing summary

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bb0e64808323a6a6916c5b410c6d